### PR TITLE
Fix "Argument passed must be of the type array..."

### DIFF
--- a/dplayer.php
+++ b/dplayer.php
@@ -202,7 +202,7 @@ EOF;
                     $body = $response['body']; // use the content
                     $json_data = @json_decode($body, true);
                     $json_dplayer_version = @$json_data['version'];
-                    if (preg_grep('/^[\d\.]+$/', $json_dplayer_version)) {
+                    if (preg_grep('/^[\d\.]+$/', (array) $json_dplayer_version)) {
                         if (strcmp($dplayer_version, $json_dplayer_version) != 0) {
                             update_option( 'kblog_danmaku_dplayer_version', $json_dplayer_version );
                             $dplayer_version = $json_dplayer_version;


### PR DESCRIPTION
I got a situation, the page is not shown, then found on apache error log...
PHP Fatal error: uncaught TypeError: prege_grep(): Argument #2 ($array) must be of type array, string given in ..../wp-content/plugins/dplayer-for-wp/dplayer.php:205

So I googled :-) and fixed this.